### PR TITLE
Fixed bug where BSD::Resource was not being loaded on OSX

### DIFF
--- a/lib/Process/SizeLimit/Core.pm
+++ b/lib/Process/SizeLimit/Core.pm
@@ -160,6 +160,8 @@ BEGIN {
         *_platform_getppid = \&_perl_getppid;
     }
     elsif ($Config{'osname'} =~ /darwin/i) {
+        _load('BSD::Resource');
+
         *_platform_check_size   = \&_darwin_size_check;
         *_platform_getppid = \&_perl_getppid;
     }

--- a/t/1-osx.t
+++ b/t/1-osx.t
@@ -1,0 +1,20 @@
+#! /usr/bin/env perl
+
+BEGIN {
+    # fake loading of Config module
+    $INC{Config} = 1;
+    %Config::Config = ( 
+        osname => 'darwin'
+    );
+}
+
+use strict;
+use warnings;
+use Test::More;
+
+# Ensure module can be used on OSX
+ok( !$INC{'BSD/Resource.pm'}, 'BSD::Resource not loaded yet' );
+use_ok('Process::SizeLimit::Core');
+ok( $INC{'BSD/Resource.pm'}, 'BSD::Resource loaded on OSX' );
+
+done_testing;


### PR DESCRIPTION
Hello,

I fixed a bug where BSD::Resource was being called and never being loaded on OSX which cause this module to blow up. Unit tests included as well :-)

Pull please?

Thanks!
