### PR TITLE
Fix Mac OS X version detection on 10.9.1.

### DIFF
--- a/lib/Process/SizeLimit/Core.pm
+++ b/lib/Process/SizeLimit/Core.pm
@@ -161,7 +161,10 @@ BEGIN {
     }
     elsif ($Config{'osname'} =~ /darwin/i) {
         _load('BSD::Resource');
-        if (qx[sw_vers -productVersion] - 10 >= 0.9) {
+        my $ver = qx[sw_vers -productVersion] || 0;
+        chomp $ver;
+        $ver =~ s/^(\d+\.\d+)\.\d+$/$1/;
+        if ($ver - 10 >= 0.9) {
             # OSX 10.9+ has no concept of rshrd in top
             *_platform_check_size   = \&_bsd_size_check;
         }


### PR DESCRIPTION
Fix for Mac OS X 10.9.1. `sw_vers -productVersion` returns "10.9.1\n" and got following warnings at loading module.

```
Argument "10.9.1\n" isn't numeric in subtraction (-) /path/to/Process/SizeLimit/Core.pm line 164.
```
